### PR TITLE
Добавил поддержку docker-compose

### DIFF
--- a/GaB_Core.sln
+++ b/GaB_Core.sln
@@ -5,7 +5,7 @@ VisualStudioVersion = 17.8.34511.84
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GaB_Core", "GaB_Core\GaB_Core.csproj", "{6BC2DB14-2312-4E26-89B5-8321E16A1A12}"
 EndProject
-Project("{E53339B2-1760-4266-BCC7-CA923CBCF16C}") = "docker-compose", "docker-compose.dcproj", "{53D8108E-C193-4B89-B7B9-BA24A4514282}"
+Project("{E53339B2-1760-4266-BCC7-CA923CBCF16C}") = "docker-compose", "docker-compose.dcproj", "{3862B691-9D45-4757-A8F6-D9768684C318}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -17,10 +17,10 @@ Global
 		{6BC2DB14-2312-4E26-89B5-8321E16A1A12}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6BC2DB14-2312-4E26-89B5-8321E16A1A12}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6BC2DB14-2312-4E26-89B5-8321E16A1A12}.Release|Any CPU.Build.0 = Release|Any CPU
-		{53D8108E-C193-4B89-B7B9-BA24A4514282}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{53D8108E-C193-4B89-B7B9-BA24A4514282}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{53D8108E-C193-4B89-B7B9-BA24A4514282}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{53D8108E-C193-4B89-B7B9-BA24A4514282}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3862B691-9D45-4757-A8F6-D9768684C318}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3862B691-9D45-4757-A8F6-D9768684C318}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3862B691-9D45-4757-A8F6-D9768684C318}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3862B691-9D45-4757-A8F6-D9768684C318}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/GaB_Core/Controllers/Example.cs
+++ b/GaB_Core/Controllers/Example.cs
@@ -28,11 +28,11 @@ namespace GaB_Core.Controllers
         }
 
         /// <summary>
-        /// Рандомайзер погоды
+        /// Р Р°РЅРґРѕРјР°Р№Р·РµСЂ РїРѕРіРѕРґС‹
         /// </summary>
-        /// <param name="id">Рандомный параметр</param>
+        /// <param name="id">Р Р°РЅРґРѕРјРЅС‹Р№ РїР°СЂР°РјРµС‚СЂ</param>
         /// <returns>
-        /// Погода в Перми
+        /// РџРѕРіРѕРґР° РІ РџРµСЂРјРё
         /// </returns>
         [HttpGet(Name = "GetWeatherForecast")]
         public IEnumerable<WeatherForecast> Get(int id)

--- a/GaB_Core/Documentation.xml
+++ b/GaB_Core/Documentation.xml
@@ -78,6 +78,18 @@
         <member name="M:GaB_Core.Migrations.FKs.BuildTargetModel(Microsoft.EntityFrameworkCore.ModelBuilder)">
             <inheritdoc />
         </member>
+        <member name="T:GaB_Core.Migrations._0030">
+            <inheritdoc />
+        </member>
+        <member name="M:GaB_Core.Migrations._0030.Up(Microsoft.EntityFrameworkCore.Migrations.MigrationBuilder)">
+            <inheritdoc />
+        </member>
+        <member name="M:GaB_Core.Migrations._0030.Down(Microsoft.EntityFrameworkCore.Migrations.MigrationBuilder)">
+            <inheritdoc />
+        </member>
+        <member name="M:GaB_Core.Migrations._0030.BuildTargetModel(Microsoft.EntityFrameworkCore.ModelBuilder)">
+            <inheritdoc />
+        </member>
         <member name="T:GaB_Core.Migrations.UnprotectedDb.InitialCreate">
             <inheritdoc />
         </member>
@@ -112,6 +124,18 @@
             <inheritdoc />
         </member>
         <member name="M:GaB_Core.Migrations.UnprotectedDb.AddAddressVM.BuildTargetModel(Microsoft.EntityFrameworkCore.ModelBuilder)">
+            <inheritdoc />
+        </member>
+        <member name="T:GaB_Core.Migrations.UnprotectedDb._0030">
+            <inheritdoc />
+        </member>
+        <member name="M:GaB_Core.Migrations.UnprotectedDb._0030.Up(Microsoft.EntityFrameworkCore.Migrations.MigrationBuilder)">
+            <inheritdoc />
+        </member>
+        <member name="M:GaB_Core.Migrations.UnprotectedDb._0030.Down(Microsoft.EntityFrameworkCore.Migrations.MigrationBuilder)">
+            <inheritdoc />
+        </member>
+        <member name="M:GaB_Core.Migrations.UnprotectedDb._0030.BuildTargetModel(Microsoft.EntityFrameworkCore.ModelBuilder)">
             <inheritdoc />
         </member>
         <member name="P:GaB_Core.ProtectedDbConnector.ProtectedDbContext.Clients">

--- a/GaB_Core/GaB_Core.csproj
+++ b/GaB_Core/GaB_Core.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
+	<UserSecretsId>d21b6399-c006-40f3-97d0-b6c57097bec6</UserSecretsId>
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>disable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <InvariantGlobalization>false</InvariantGlobalization>
-    <UserSecretsId>d21b6399-c006-40f3-97d0-b6c57097bec6</UserSecretsId>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
 	<GenerateDocumentationFile>True</GenerateDocumentationFile>
 	<DocumentationFile>Documentation.xml</DocumentationFile>
@@ -13,8 +13,9 @@
 	<Company>Get a Blanket</Company>
 	<Authors>Get a Blanket</Authors>
 	<Product>Core</Product>
-	<AssemblyVersion>0.0.3.0</AssemblyVersion>
+	<AssemblyVersion>0.0.3.1</AssemblyVersion>
 	<DockerComposeProjectPath>..\docker-compose.dcproj</DockerComposeProjectPath>
+	<ContainerDevelopmentMode>Regular</ContainerDevelopmentMode>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/GaB_Core/Properties/launchSettings.json
+++ b/GaB_Core/Properties/launchSettings.json
@@ -19,25 +19,6 @@
       },
       "dotnetRunMessages": true,
       "applicationUrl": "https://localhost:7272;http://localhost:5226"
-    },
-    "IIS Express": {
-      "commandName": "IISExpress",
-      "launchBrowser": true,
-      "launchUrl": "swagger",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      }
-    },
-    "Docker": {
-      "commandName": "Docker",
-      "launchBrowser": true,
-      "launchUrl": "{Scheme}://{ServiceHost}:{ServicePort}/swagger",
-      "environmentVariables": {
-        "ASPNETCORE_HTTPS_PORTS": "8081",
-        "ASPNETCORE_HTTP_PORTS": "8080"
-      },
-      "publishAllPorts": true,
-      "useSSL": true
     }
   },
   "$schema": "http://json.schemastore.org/launchsettings.json",

--- a/GaB_Core/appsettings.Development.json
+++ b/GaB_Core/appsettings.Development.json
@@ -7,7 +7,7 @@
   },
   "AllowedHosts": "*",
   "ConnectionStrings": {
-    "UnprotectedDatabase": "Host=localhost; Database=UnsecureDB; Username=postgres; Password=admin",
-    "ProtectedDatabase": "Host=localhost; Database=SecureDB; Username=postgres; Password=admin"
+    "UnprotectedDatabase": "Host=postgresql; Database=UnsecureDB; Username=postgres; Password=admin",
+    "ProtectedDatabase": "Host=postgresql; Database=SecureDB; Username=postgres; Password=admin"
   }
 }

--- a/GaB_Core/appsettings.json
+++ b/GaB_Core/appsettings.json
@@ -7,7 +7,7 @@
   },
   "AllowedHosts": "*",
   "ConnectionStrings": {
-    "UnprotectedDatabase": "Host=localhost; Database=UnsecureDB; Username=postgres; Password=admin",
-    "ProtectedDatabase": "Host=localhost; Database=SecureDB; Username=postgres; Password=admin"
+    "UnprotectedDatabase": "Host=postgresql; Database=UnsecureDB; Username=postgres; Password=admin",
+    "ProtectedDatabase": "Host=postgresql; Database=SecureDB; Username=postgres; Password=admin"
   }
 }

--- a/GaB_Core/dev.Dockerfile
+++ b/GaB_Core/dev.Dockerfile
@@ -1,26 +1,30 @@
 #See https://aka.ms/customizecontainer to learn how to customize your debug container and how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS base
 USER app
 WORKDIR /app
 EXPOSE 8080
 EXPOSE 8081
-EXPOSE 5432
 
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
-ARG BUILD_CONFIGURATION=Release
+ARG BUILD_CONFIGURATION=Debug
 WORKDIR /src
+RUN dotnet tool install --global dotnet-ef --version 8.*
+ENV PATH="$PATH:/root/.dotnet/tools"
 COPY ["GaB_Core/GaB_Core.csproj", "GaB_Core/"]
 RUN dotnet restore "./GaB_Core/GaB_Core.csproj"
 COPY . .
+RUN dotnet ef migrations add docker-build --context GaB_Core.UnprotectedDbConnector.UnprotectedDbContext --project ./GaB_Core
+RUN dotnet ef migrations add docker-build --context GaB_Core.ProtectedDbConnector.ProtectedDbContext --project ./GaB_Core
 WORKDIR "/src/GaB_Core"
 RUN dotnet build "./GaB_Core.csproj" -c $BUILD_CONFIGURATION -o /app/build
 
 FROM build AS publish
-ARG BUILD_CONFIGURATION=Release
+ARG BUILD_CONFIGURATION=Debug
 RUN dotnet publish "./GaB_Core.csproj" -c $BUILD_CONFIGURATION -o /app/publish /p:UseAppHost=false
 
 FROM base AS final
 WORKDIR /app
 COPY --from=publish /app/publish .
+RUN dotnet dev-certs https
 ENTRYPOINT ["dotnet", "GaB_Core.dll"]

--- a/docker-compose.dcproj
+++ b/docker-compose.dcproj
@@ -4,16 +4,17 @@
     <ProjectVersion>2.1</ProjectVersion>
     <DockerTargetOS>Linux</DockerTargetOS>
     <DockerPublishLocally>False</DockerPublishLocally>
-    <ProjectGuid>53d8108e-c193-4b89-b7b9-ba24a4514282</ProjectGuid>
+    <ProjectGuid>3862b691-9d45-4757-a8f6-d9768684c318</ProjectGuid>
     <DockerLaunchAction>LaunchBrowser</DockerLaunchAction>
     <DockerServiceUrl>{Scheme}://localhost:{ServicePort}/swagger</DockerServiceUrl>
     <DockerServiceName>gab_core</DockerServiceName>
+	<DockerDevelopmentMode>Regular</DockerDevelopmentMode>
   </PropertyGroup>
   <ItemGroup>
     <None Include="docker-compose.override.yml">
       <DependentUpon>docker-compose.yml</DependentUpon>
     </None>
     <None Include="docker-compose.yml" />
-    <None Include=".dockerignore" />
+	<None Include=".dockerignore" />
   </ItemGroup>
 </Project>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,24 @@ version: '3.4'
 
 services:
   gab_core:
-    image: ${DOCKER_REGISTRY-}gabcore
+    # image: ${DOCKER_REGISTRY-}gabcore
     build:
       context: .
-      dockerfile: GaB_Core/Dockerfile
+      dockerfile: GaB_Core/dev.Dockerfile
+
+  postgresql:
+    image: postgres:16
+    restart: always
+    environment:
+      POSTGRES_PASSWORD: admin
+    volumes:
+      - db-data:/var/lib/postgresql/data
+    ports:
+      - 5433:5432
+
+networks:
+  default:
+  
+volumes:
+  db-data:
+    external: true

--- a/launchSettings.json
+++ b/launchSettings.json
@@ -3,8 +3,12 @@
     "Docker Compose": {
       "commandName": "DockerCompose",
       "commandVersion": "1.0",
+      "composeLaunchAction": "LaunchBrowser",
+      "composeLaunchServiceName": "gab_core",
+      "composeLaunchUrl": "{Scheme}://localhost:{ServicePort}/swagger",
       "serviceActions": {
-        "gab_core": "StartDebugging"
+        "gab_core": "StartDebugging",
+        "postgresql": "StartWithoutDebugging"
       }
     }
   }


### PR DESCRIPTION
Добавил docker-compose. В вижаке он запускается просто как отдельный проект, выбирается сверху. Лучше всегда запускать через него, потому что он внутри себя создаёт миграцию. 
**Внимание**, из-за этого он может попортить базу данных, которая у тебя хранится в докере, так что лучше лишний раз схему бд не трогать. Но это актуально и для ручного запуска, просто в ручном запуске ты явно выполняешь миграцию, что помогает тебе осознавать ~~в какую жопу ты себя тянешь~~ какие последствия для бд это может иметь.
В остальном никаких изменений, на файлы типа .csproj .sln .json можешь не смотреть, это просто файлы конфигурации вижака.

P.S. Я в рот %;№% разработчиков вижака с их настройками